### PR TITLE
Refactor : Make engine.c adhere to its set of responsibilities

### DIFF
--- a/engine.h
+++ b/engine.h
@@ -32,13 +32,16 @@ typedef void ( *T_AT_UART_Write )(unsigned int data_out);
 typedef void ( *T_AT_UART_Write )(unsigned char data_out);
 #else
 typedef void ( *T_AT_UART_Write )(unsigned char data_out);
+typedef uint8_t ( *T_AT_UART_Read  )(void);
 #endif
 
 /*----------------------------------------------------------------------------*/
 
-void init_engine(T_AT_UART_Write fp_uart_write);
+void init_engine(T_AT_UART_Write write_handler, T_AT_UART_Read read_handler);
 
-static void send_text_via_uart(const char* str);
+static void send_text_via_uart(const char* data_out);
+
+static void retrieve_uart_buffer_content(char *const data_in);
 
 /**
  * @brief Simple AT Command

--- a/main.c
+++ b/main.c
@@ -78,7 +78,7 @@ void main(void)
     //INTERRUPT_PeripheralInterruptDisable();
     
 
-    init_engine(EUSART1_Write);
+    init_engine(EUSART1_Write, EUSART1_Read);
     init_atcmd_parser(esp8266_default_atcmd_handler, 100, handlers_store);
     save_atcmd_handler("+CWMODE", 100, esp8266_default_atcmd_handler);
     execute_atcmd("ATE0");


### PR DESCRIPTION
Function execute_atcmd in engine.c should execute the AT command once and parse the response to something user-readable.
Engine should be pointed to microcontroller- and/or compiler-specific function that handles reading of data received from UART module and not call the function directly.
These refactoring enhance modularity to the point that engine and at_parser can be used as libraries (as intended).

Changes:
- Removed for-loop in execute_atcmd which repeats sending of AT command if original response to AT command is a failure.
- Add function pointer to function handling receiving data from UART module as parameter to init_engine.
- Add static function that uses previously mentioned function pointer to copy contents of buffer used to store data received from UART module to a local buffer.

Resolves: #3